### PR TITLE
add ENV settings

### DIFF
--- a/docker/oktoberfest/Dockerfile
+++ b/docker/oktoberfest/Dockerfile
@@ -8,6 +8,9 @@ COPY --chown=mambauser:mambauser requirements.txt /home/mambauser/
 USER mambauser
 ENV HOME=/home/mambauser
 ENV ENV_NAME=oktoberfest
+ENV LD_LIBRARY_PATH=/opt/conda/envs/oktoberfest/lib
+ENV MPLCONFIGDIR=/tmp/matplotlib
+ENV NUMBA_CACHE_DIR=/tmp/numba_cache
 
 RUN echo 'show_banner: false' > ~/.mambarc \
     && micromamba env create -y -f /home/mambauser/environment.yml \


### PR DESCRIPTION
This pull request makes several environment configuration improvements to the `docker/oktoberfest/Dockerfile` to ensure smoother runtime behavior for Python libraries and tools.

Environment variable configuration:

* Added `LD_LIBRARY_PATH` to point to the correct library directory for the `oktoberfest` conda environment, helping dynamic libraries to be found at runtime.
* Set `MPLCONFIGDIR` to `/tmp/matplotlib` to avoid permission issues when matplotlib writes config files, especially in containerized environments.
* Set `NUMBA_CACHE_DIR` to `/tmp/numba_cache` to ensure Numba can cache compiled functions without permission errors.